### PR TITLE
Update pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -7,14 +7,20 @@
             "platform": "linux",
             "archive": true,
             "includes": ["pawno/include"],
-            "plugins": ["plugins/audio.so"]
+            "plugins": ["plugins/audio.so"],
+            "files": {
+                "audio.ini": "audio.ini",
+            }
         },
         {
             "name": "^samp-audio-server-plugin-(.*).zip$",
             "platform": "windows",
             "archive": true,
             "includes": ["pawno/include"],
-            "plugins": ["plugins/audio.dll"]
+            "plugins": ["plugins/audio.dll"],
+            "files": {
+                "audio.ini": "audio.ini",
+            }
         }
     ],
     "runtime": {

--- a/pawn.json
+++ b/pawn.json
@@ -9,7 +9,7 @@
             "includes": ["pawno/include"],
             "plugins": ["plugins/audio.so"],
             "files": {
-                "audio.ini": "audio.ini",
+                "audio.ini": "audio.ini"
             }
         },
         {
@@ -19,7 +19,7 @@
             "includes": ["pawno/include"],
             "plugins": ["plugins/audio.dll"],
             "files": {
-                "audio.ini": "audio.ini",
+                "audio.ini": "audio.ini"
             }
         }
     ],


### PR DESCRIPTION
audio.ini file should be copied as well. Unfortunately `audiopackages` folder is not possible to copy with its content to the `runtime` folder. Unless someone's got an idea.