### PR TITLE
Add attribute const to name parameter on Audio_SetPlayerName

### DIFF
--- a/audio.inc
+++ b/audio.inc
@@ -179,7 +179,7 @@ forward Audio_OnPlayerDisconnect(playerid, reason);
 
 // Native Hook Section
 
-stock Audio_SetPlayerName(playerid, name[])
+stock Audio_SetPlayerName(playerid, const name[])
 {
 	new value = SetPlayerName(playerid, name);
 	if (value > 0)


### PR DESCRIPTION
This for remove the compiler warning:
(warning) possibly a "const" array argument was intended: "name"